### PR TITLE
Range Setting Feature

### DIFF
--- a/settings.lua
+++ b/settings.lua
@@ -5,5 +5,13 @@ data:extend({
       localised_name = "Hide paths (Increases UPS)",
       setting_type = "runtime-global",
       default_value = false
+  },
+	
+  {
+      type = "double-setting",
+      name = "repair_turret_range",
+      localised_name = "Repair Range",
+      setting_type = "startup",
+      default_value = 25
   }
 })

--- a/shared.lua
+++ b/shared.lua
@@ -7,6 +7,6 @@ data.entities =
   repair_turret = "repair-turret",
 }
 
-data.repair_range = 25
+data.repair_range = settings.startup["repair_turret_range"].value
 
 return data


### PR DESCRIPTION
Adds a startup setting that allows the user to set a custom repair range for the turret.