### PR TITLE
Fixed spelling error

### DIFF
--- a/locale/en/repair-turret.cfg
+++ b/locale/en/repair-turret.cfg
@@ -5,5 +5,5 @@ repair-turret-power-description=Repair turret power: +100%
 repair-turret-efficiency=Repair turret efficiency
 repair-turret-efficiency-description=Repair turret efficiency: +25%
 repair-turret-construction=Repair turret construction upgrade
-repair-turret-construction-description=Enables repair turrets to contruct ghosts using items from the logistic system.
+repair-turret-construction-description=Enables repair turrets to construct ghosts using items from the logistic system.
 repair-turret-deconstruction-description=Enables repair turrets to deconstruct entities and put the items into the logistic system.


### PR DESCRIPTION
`contruct` was written instead of `construct`