### PR TITLE
Prevent repair turrets from spilling onto belts

### DIFF
--- a/script/repair_turret.lua
+++ b/script/repair_turret.lua
@@ -732,7 +732,7 @@ local deconstruct_entity = function(turret, entity)
     end
     if count > 0 then
       stack.count = count
-      surface.spill_item_stack(position, stack)
+      surface.spill_item_stack(position, stack, false, nil, false)
     end
     stack.clear()
   end


### PR DESCRIPTION
Keeps `enable_looted` & `force` at their default values.

It is a fairly common occurrence that the repair turret decides to spill all-over instead of waiting for the entity's inventory to be properly emptied, this change won't solve the root cause but at least make the aftermath less of a cleanup.