### PR TITLE
Update changelog.txt

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -155,16 +155,6 @@ Date: 2019-12-16
   Changes:
     - Fixed turrets not healing properly on entities near the edge of their range.
 ---------------------------------------------------------------------------------------------------
-Version: 0.2.5
-Date: 2019-12-18
-  Changes:
-    - Fixed error on migration.
----------------------------------------------------------------------------------------------------
-Version: 0.2.4
-Date: 2019-12-16
-  Changes:
-    - Fixed turrets not healing properly on entities near the edge of their range.
----------------------------------------------------------------------------------------------------
 Version: 0.2.3
 Date: 2019-12-15
   Changes:


### PR DESCRIPTION
Removed duplicate entries that caused parsing errors which prevented viewing the changelog in-game

`Failed to parse changelog for mod Repair Turret: invalid changelog file, error on line 159, duplicate Date: line or duplicate Version: line.`