### PR TITLE
Raise script_raised_set_tiles when turret sets tiles

### DIFF
--- a/script/repair_turret.lua
+++ b/script/repair_turret.lua
@@ -862,7 +862,7 @@ RepairTurret.deconstruct_entity = function(self, entity)
   local force = self.entity.force
 
   if tiles then
-    surface.set_tiles(tiles, raise_event = true)
+    surface.set_tiles(tiles, nil, nil, nil, true)
   end
 
   local source_position = {self.position.x, self.position.y - 2.5}

--- a/script/repair_turret.lua
+++ b/script/repair_turret.lua
@@ -862,7 +862,7 @@ RepairTurret.deconstruct_entity = function(self, entity)
   local force = self.entity.force
 
   if tiles then
-    surface.set_tiles(tiles)
+    surface.set_tiles(tiles, raise_event = true)
   end
 
   local source_position = {self.position.x, self.position.y - 2.5}


### PR DESCRIPTION
We've talked about this a while back over Discord but I'd like to hook into the deletion of my modded tiles to run some cleanup code. But the raise_event flag isn't set.